### PR TITLE
Humanize fix

### DIFF
--- a/lib/hiccup/humanizable.rb
+++ b/lib/hiccup/humanizable.rb
@@ -50,7 +50,7 @@ module Hiccup
         ordinal = _skip.human_ordinalize
         sentence(ordinal, weekday.humanize)
       else
-        monthly_occurrence.ordinalize
+        monthly_occurrence < 0 ? "last day" : monthly_occurrence.ordinalize
       end
     end
     

--- a/test/humanizable_test.rb
+++ b/test/humanizable_test.rb
@@ -42,6 +42,10 @@ class HumanizableTest < ActiveSupport::TestCase
     {:kind => :monthly, :monthly_pattern => [4,5]})
     
   test_humanize(
+    "The last day of every month",
+    {:kind => :monthly, :monthly_pattern => [-1]})
+
+  test_humanize(
     "The first Monday of every month",
     {:kind => :monthly, :monthly_pattern => [[1, "Monday"]]})
     


### PR DESCRIPTION
This breaks your convention a little. We wanted to just change it to `monthly_occurrance.human_ordinalize`, but that turns the ordinals (up to 20) into the text version [2nd -> second]. If you'd like a different method to fix this issue, just say.