### PR TITLE
Fix bug with monthly occurrences and skip

### DIFF
--- a/lib/hiccup/enumerable/monthly_enumerator.rb
+++ b/lib/hiccup/enumerable/monthly_enumerator.rb
@@ -52,6 +52,11 @@ module Hiccup
       
       def first_occurrence_on_or_after(date)
         @year, @month = date.year, date.month
+        if skip > 1
+          offset = months_since_schedule_start(@year, @month)
+          add_to_months offset % skip
+        end
+        
         get_context
         
         @position = cycle.index { |day| day >= date.day }
@@ -66,6 +71,11 @@ module Hiccup
       
       def first_occurrence_on_or_before(date)
         @year, @month = date.year, date.month
+        if skip > 1
+          offset = months_since_schedule_start(@year, @month)
+          subtract_from_months offset % skip
+        end
+        
         get_context
         
         @position = cycle.rindex { |day| day <= date.day }
@@ -127,6 +137,11 @@ module Hiccup
         @cycle = occurrences_in_month(year, month).sort
       end
       
+      
+      
+      def months_since_schedule_start(year, month)
+        (year - start_date.year) * 12 + (month - start_date.month)
+      end
       
       
     end

--- a/lib/hiccup/enumerable/monthly_enumerator.rb
+++ b/lib/hiccup/enumerable/monthly_enumerator.rb
@@ -101,16 +101,24 @@ module Hiccup
       
       def next_month
         @position = 0
-        @month += skip
-        @year, @month = year + 1, month - 12 if month > 12
+        add_to_months skip
         get_context
+      end
+      
+      def add_to_months(offset)
+        @month += offset
+        @year, @month = @year + 1, @month - 12 while @month > 12
       end
       
       def prev_month
         @position = @cycle.length - 1
-        @month -= skip
-        @year, @month = year - 1, month + 12 if month < 1
+        subtract_from_months skip
         get_context
+      end
+      
+      def subtract_from_months(offset)
+        @month -= offset
+        @year, @month = @year - 1, @month + 12 while @month < 1
       end
       
       def get_context

--- a/test/monthly_enumerator_test.rb
+++ b/test/monthly_enumerator_test.rb
@@ -22,7 +22,6 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
     end
     
     context "when enumerating backward" do
-      
       should "return the most-recent date prior to the start_date, NOT the earliest date in the month" do
         # Start with a date in the middle of the month
         # More than one date prior to the seed date, yet
@@ -31,8 +30,33 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
         enumerator = @schedule.enumerator.new(@schedule, date)
         assert_equal Date.new(2013, 10, 13), enumerator.prev
       end
-      
     end
   end
+  
+  
+  context "with a schedule that skips" do
+    setup do
+      @schedule = Schedule.new(
+        kind: :monthly,
+        skip: 2,
+        monthly_pattern: [[1, "Thursday"]],
+        start_date: Date.new(2015, 1, 1))
+    end
+    
+    context "when enumerating from the start date" do
+      should "skip months from the schedule's start date" do
+        assert_equal [Date.new(2015, 1, 1), Date.new(2015, 3, 5), Date.new(2015, 5, 7)],
+                     @schedule.occurrences_between(Date.new(2015, 1, 1), Date.new(2015, 5, 31))
+      end
+    end
+    
+    context "when enumerating from an offset" do
+      should "skip months from the schedule's start date not from the offset" do
+        assert_equal [Date.new(2015, 3, 5), Date.new(2015, 5, 7)],
+                     @schedule.occurrences_between(Date.new(2015, 2, 1), Date.new(2015, 6, 30))
+      end
+    end
+  end
+  
   
 end


### PR DESCRIPTION
Given a monthly schedule skipped certain months (like `The first Thursday of every other month`)

If you asked that schedule if it contains a certain date, it would always start the skip pattern in the month you asked about.

So:
```ruby
schedule = Schedule.new(kind: :monthly, skip: 2, monthly_pattern: [[1, "Thursday"]], start_date: Date.new(2015, 1, 1))
schedule.contains? Date.new(2015, 2, 5) # => returns `true` because 2/5 is a Thursday and it's treating February as the start of the skipping pattern
schedule.occurrences_between Date.new(2015, 2, 1), Date.new(2015, 5, 31) # => returns 2/5 and 4/2
```