### PR TITLE
Fixed last of the month

### DIFF
--- a/lib/hiccup/enumerable/monthly_enumerator.rb
+++ b/lib/hiccup/enumerable/monthly_enumerator.rb
@@ -102,15 +102,21 @@ module Hiccup
 
 
       def occurrences_in_month(year, month)
-        wday_of_first_of_month = Date.new(year, month, 1).wday
         monthly_pattern.map do |occurrence|
           if occurrence.is_a?(Array)
             ordinal, weekday = occurrence
             wday = Date::DAYNAMES.index(weekday)
             day = wday
-            day = day + 7 if (wday < wday_of_first_of_month)
-            day = day - wday_of_first_of_month
-            day = day + (ordinal * 7) - 6
+            if ordinal < 0
+              wday_of_last_of_month = Date.new(year, month, -1).wday
+              day = day + 7 if wday <= wday_of_last_of_month
+              day = day - wday_of_last_of_month + (ordinal * 7) - 1
+            else
+              wday_of_first_of_month = Date.new(year, month, 1).wday
+              day = day + 7 if (wday < wday_of_first_of_month)
+              day = day - wday_of_first_of_month
+              day = day + (ordinal * 7) - 6
+            end
             day
           else
             occurrence

--- a/test/monthly_enumerator_test.rb
+++ b/test/monthly_enumerator_test.rb
@@ -92,8 +92,6 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
       )
       enumerator = @schedule.enumerator.new(@schedule, date)
       assert_equal Date.new(2015, 1, 25), enumerator.next
-      assert_equal Date.new(2015, 2, 22), enumerator.next
-      assert_equal Date.new(2015, 3, 29), enumerator.next
     end
 
     should "return the last monday of the month" do
@@ -103,9 +101,7 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
         monthly_pattern: [[-1, "Monday"]],
         start_date: date
       )
-      enumerator = @schedule.enumerator.new(@schedule, date)
-      assert_equal Date.new(2015, 1, 26), enumerator.next
-      assert_equal Date.new(2015, 2, 23), enumerator.next
+      enumerator = @schedule.enumerator.new(@schedule, Date.new(2015, 2, 28))
       assert_equal Date.new(2015, 3, 30), enumerator.next
     end
 
@@ -116,10 +112,8 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
         monthly_pattern: [[-1, "Tuesday"]],
         start_date: date
       )
-      enumerator = @schedule.enumerator.new(@schedule, date)
-      assert_equal Date.new(2015, 1, 27), enumerator.next
+      enumerator = @schedule.enumerator.new(@schedule, Date.new(2015, 1, 31))
       assert_equal Date.new(2015, 2, 24), enumerator.next
-      assert_equal Date.new(2015, 3, 31), enumerator.next
     end
 
     should "return the second to last tuesday of the month" do
@@ -129,10 +123,8 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
         monthly_pattern: [[-2, "Tuesday"]],
         start_date: date
       )
-      enumerator = @schedule.enumerator.new(@schedule, date)
-      assert_equal Date.new(2015, 1, 20), enumerator.next
-      assert_equal Date.new(2015, 2, 17), enumerator.next
-      assert_equal Date.new(2015, 3, 24), enumerator.next
+      enumerator = @schedule.enumerator.new(@schedule, Date.new(2015, 2, 28))
+      assert_equal Date.new(2015, 2, 17), enumerator.prev
     end
   end
 

--- a/test/monthly_enumerator_test.rb
+++ b/test/monthly_enumerator_test.rb
@@ -69,6 +69,73 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
   end
 
 
+  context "last of the month" do
+    should "return the last day of the month" do
+      date = Date.new(2014, 12, 31)
+      @schedule = Schedule.new(
+        kind: :monthly,
+        monthly_pattern: [-1],
+        start_date: date
+      )
+      enumerator = @schedule.enumerator.new(@schedule, date)
+      assert_equal Date.new(2015, 1, 31), enumerator.next
+      assert_equal Date.new(2015, 2, 28), enumerator.next
+      assert_equal Date.new(2015, 3, 31), enumerator.next
+    end
+
+    should "return the last sunday of the month" do
+      date = Date.new(2014, 12, 31)
+      @schedule = Schedule.new(
+        kind: :monthly,
+        monthly_pattern: [[-1, "Sunday"]],
+        start_date: date
+      )
+      enumerator = @schedule.enumerator.new(@schedule, date)
+      assert_equal Date.new(2015, 1, 25), enumerator.next
+      assert_equal Date.new(2015, 2, 22), enumerator.next
+      assert_equal Date.new(2015, 3, 29), enumerator.next
+    end
+
+    should "return the last monday of the month" do
+      date = Date.new(2014, 12, 31)
+      @schedule = Schedule.new(
+        kind: :monthly,
+        monthly_pattern: [[-1, "Monday"]],
+        start_date: date
+      )
+      enumerator = @schedule.enumerator.new(@schedule, date)
+      assert_equal Date.new(2015, 1, 26), enumerator.next
+      assert_equal Date.new(2015, 2, 23), enumerator.next
+      assert_equal Date.new(2015, 3, 30), enumerator.next
+    end
+
+    should "return the last tuesday of the month" do
+      date = Date.new(2014, 12, 31)
+      @schedule = Schedule.new(
+        kind: :monthly,
+        monthly_pattern: [[-1, "Tuesday"]],
+        start_date: date
+      )
+      enumerator = @schedule.enumerator.new(@schedule, date)
+      assert_equal Date.new(2015, 1, 27), enumerator.next
+      assert_equal Date.new(2015, 2, 24), enumerator.next
+      assert_equal Date.new(2015, 3, 31), enumerator.next
+    end
+
+    should "return the second to last tuesday of the month" do
+      date = Date.new(2014, 12, 31)
+      @schedule = Schedule.new(
+        kind: :monthly,
+        monthly_pattern: [[-2, "Tuesday"]],
+        start_date: date
+      )
+      enumerator = @schedule.enumerator.new(@schedule, date)
+      assert_equal Date.new(2015, 1, 20), enumerator.next
+      assert_equal Date.new(2015, 2, 17), enumerator.next
+      assert_equal Date.new(2015, 3, 24), enumerator.next
+    end
+  end
+
   context "with an empty schedule" do
     setup do
       @schedule = Schedule.new(


### PR DESCRIPTION
Monthly patterns like `[-1, "Sunday"]` weren't working correctly. The only thing that _did_ work was `[-1]`, which returned the last day of the month. 

This PR allows one to do `[-1, "Sunday"]` (last Sunday of the month) or even `[-2, "Sunday"]` (second to last Sunday of the month).

We might want to refactor the tests.