### PR TITLE
Added `skip` to `to_hash`

### DIFF
--- a/lib/hiccup/schedule.rb
+++ b/lib/hiccup/schedule.rb
@@ -36,7 +36,8 @@ module Hiccup
         :ends => ends,
         :end_date => end_date,
         :weekly_pattern => weekly_pattern,
-        :monthly_pattern => monthly_pattern
+        :monthly_pattern => monthly_pattern,
+        :skip => skip
       }
     end
 


### PR DESCRIPTION
Humanize requires the hashed schedule, but to determine "Every x Sundays" we need to know what the skip value is if the schedule is "Every 4 Sundays".