### PR TITLE
Only write a single MONTHLY rule when serializing to iCal format

### DIFF
--- a/lib/hiccup/serializers/ical.rb
+++ b/lib/hiccup/serializers/ical.rb
@@ -73,7 +73,7 @@ module Hiccup
           end
         end
 
-        add_rule("MONTHLY", :bymonthday => bymonthday) if bymonthday.any?
+        return add_rule("MONTHLY", :bymonthday => bymonthday) if bymonthday.any?
         add_rule("MONTHLY", :byday => byday) if byday.any?
       end
 


### PR DESCRIPTION
I couldn't find the exact rule in the RFC 2445, but having multiple `RRULE:FREQ=MONTHLY;...` in an iCal file was confusing GCal and MS Outlook.