### PR TITLE
Removed deprecation warnings for assert_nil

### DIFF
--- a/test/enumerable_test.rb
+++ b/test/enumerable_test.rb
@@ -260,8 +260,8 @@ class EnumerableTest < ActiveSupport::TestCase
       :start_date => Date.new(2011, 1, 3),
       :ends => true,
       :end_date => Date.new(2011, 1, 31)})
-    assert_equal nil, schedule.first_occurrence_before(Date.new(2011,1,3))
-    assert_equal nil, schedule.first_occurrence_on_or_before(Date.new(2011,1,2))
+    assert_nil schedule.first_occurrence_before(Date.new(2011,1,3))
+    assert_nil schedule.first_occurrence_on_or_before(Date.new(2011,1,2))
     assert_equal [], schedule.n_occurrences_before(10, Date.new(2011,1,3))
     assert_equal [], schedule.n_occurrences_on_or_before(10, Date.new(2011,1,2))
   end
@@ -281,8 +281,8 @@ class EnumerableTest < ActiveSupport::TestCase
       :start_date => Date.new(2011, 1, 3),
       :ends => true,
       :end_date => Date.new(2011, 1, 31)})
-    assert_equal nil, schedule.first_occurrence_after(Date.new(2011,1,31))
-    assert_equal nil, schedule.first_occurrence_on_or_after(Date.new(2011,2, 1))
+    assert_nil schedule.first_occurrence_after(Date.new(2011,1,31))
+    assert_nil schedule.first_occurrence_on_or_after(Date.new(2011,2, 1))
     assert_equal [], schedule.occurrences_between(Date.new(2013, 9, 23), Date.new(2013, 9, 30))
   end
 

--- a/test/monthly_enumerator_test.rb
+++ b/test/monthly_enumerator_test.rb
@@ -160,7 +160,7 @@ class MonthlyEnumeratorTest < ActiveSupport::TestCase
     should "always return nil" do
       date = Date.new(2015, 2, 1)
       enumerator = @schedule.enumerator.new(@schedule, date)
-      assert_equal nil, enumerator.next
+      assert_nil enumerator.next
     end
   end
 

--- a/test/weekly_enumerator_test.rb
+++ b/test/weekly_enumerator_test.rb
@@ -119,12 +119,12 @@ class WeeklyEnumeratorTest < ActiveSupport::TestCase
 
     should "return nil for prev rather than raising an exception" do
       enumerator = @schedule.enumerator.new(@schedule, Date.today)
-      assert_equal nil, enumerator.prev
+      assert_nil enumerator.prev
     end
 
     should "return nil for next rather than raising an exception" do
       enumerator = @schedule.enumerator.new(@schedule, Date.today)
-      assert_equal nil, enumerator.next
+      assert_nil enumerator.next
     end
   end
 


### PR DESCRIPTION
This is just a simple update to remove the deprecation warning that assert_nil will be removed in Minitest 6.